### PR TITLE
(#18) : Orchestrate a spawn of Datomic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ SYSENV ?= etc/sysenv.yaml
 
 ## 
 ## datomic account
-USER ?=
-PASS ?=
+USER ?= none
+PASS ?= none
 VSN  ?= $(shell cat ${SYSENV} | sed -n "s/Version:[ ]*\(.*\)/\1/p")
 
 setup: src/aws/setup.yaml

--- a/README.md
+++ b/README.md
@@ -45,11 +45,20 @@ Install directions with AWS-related details are [here](doc/install.md).
 
 ### Running appliance
 
-TBD
+You can run Datomic appliance locally once your AWS account is [configured](doc/install.md). Please ensure that your have a valid AWS credentials / tokens before running the appliance.
+
+The following commands builds a Docker container and spawns Datomic and DynamoDB mock services at your Docker environment.
+```
+make docker
+make run
+```
+Datomic is available for your peers at  `datomic:ddb-local://127.0.0.1:8000/datomic/yourdb`
 
 ## Next Steps
 
-TBD
+* Learn the installation guidelines to AWS 
+* Continue with Datomic peer development
+
 
 ## Contributing/Bugs
 

--- a/src/datomic/Dockerfile
+++ b/src/datomic/Dockerfile
@@ -1,11 +1,10 @@
 FROM centos
 
-ARG PACKAGE_URL=
-
 ##
-## Install basic utilities and python
+## Install basic utilities, java and python
 RUN set -e \
    && yum -y -q update \
+   && yum -y -q install java \
    && yum -y -q install zip unzip iproute \
    && yum -y -q install python python-setuptools \
    && easy_install -U pip \
@@ -14,6 +13,8 @@ RUN set -e \
 
 ##
 ## Install datomic from S3
+ARG PACKAGE_URL=
+
 RUN set -e \
    && curl -o /tmp/datomic-latest.zip "${PACKAGE_URL}" \
    && mkdir -p /etc/datomic \

--- a/src/datomic/run.sh
+++ b/src/datomic/run.sh
@@ -1,1 +1,32 @@
+#!/bin/bash
 
+echo "==> booting ..."
+CONFIG="/etc/datomic/datomic.properties"
+
+
+##
+echo "==> discovering host ..."
+HOST=$(curl -s --connect-timeout 1 http://169.254.169.254/latest/meta-data/local-hostname)
+if [[ -z "${HOST}" ]] ;
+then
+   # service is not running at aws
+   HOST=$({ ip addr show eth0 | sed -n 's/.*inet \([0-9]*.[0-9]*.[0-9]*.[0-9]*\).*/\1/p' ; } || echo "127.0.0.1")
+   
+   export AWS_ACCESS_KEY_ID="aws-access-key-id"
+   export AWS_SECRET_ACCESS_KEY="aws-secret-key"
+   echo "${HOST}  docker" > /etc/hosts
+fi
+echo "==> running at ${HOST}"
+
+
+##
+echo "==> configure service"
+if [[ ! -f ${CONFIG} ]] ;
+then
+   echo "==> no config"
+fi
+
+
+##
+echo "==> spawn transactor"
+/usr/local/datomic/bin/transactor ${CONFIG}

--- a/src/local.yaml
+++ b/src/local.yaml
@@ -8,4 +8,6 @@ services:
   datomic:
     image: datomic:0.9.5561
     ports:
-     - "4334:4334"
+      - "4334:4334"
+    volumes_from:
+      - container:datomic-config


### PR DESCRIPTION
__WHY__
The service is need for local RnD purposes
See #18.

__WHAT__
* tune bootstrap to configure itself for docker
* docker composer to orchestrate bootstrap