### PR TITLE
(#16) : update a documentation for lisence mgmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ upload: license.txt
 resources: src/aws/resources.yaml
 	@sh src/scripts/resources.sh -f $^ -c ${SYSENV}
 
+license: 
+	@sh src/scripts/config.sh
+
 docker: src/datomic/Dockerfile
 	@U=`sh src/scripts/s3url.sh` ;\
 	docker build --build-arg="PACKAGE_URL=$$U" -t datomic:${VSN} -f $^ src/datomic/
@@ -25,4 +28,4 @@ docker: src/datomic/Dockerfile
 run: src/local.yaml
 	docker-compose -f $^ up
 
-.PHONY: setup upload resources
+.PHONY: setup upload resources license docker run

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Install directions with AWS-related details are [here](doc/install.md).
 
 You can run Datomic appliance locally once your AWS account is [configured](doc/install.md). Please ensure that your have a valid AWS credentials / tokens before running the appliance.
 
+The first run of the appliance requires a license, run the following command to obtain license. 
+```
+make license
+``` 
+
 The following commands builds a Docker container and spawns Datomic and DynamoDB mock services at your Docker environment.
 ```
 make docker

--- a/doc/install.md
+++ b/doc/install.md
@@ -39,7 +39,7 @@ make upload USER=your@e.mail PASS=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
 
-## Deploy Datomic
+## Deploy Datomic to AWS
 
 ### Provision resources
 


### PR DESCRIPTION
__WHY__
The execution of Datomic requires a valid license.
The docker volume feature is used to persist license on local machine

See #16