### PR TITLE
(#12) : add scm-source file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.zip
 datomic.license
 license.*
+scm-source.json
 

--- a/src/datomic/Dockerfile
+++ b/src/datomic/Dockerfile
@@ -25,5 +25,7 @@ RUN set -e \
 
 EXPOSE 4334
 
+COPY scm-source.json /scm-source.json
 COPY run.sh /usr/local/datomic/
 ENTRYPOINT ["bash", "/usr/local/datomic/run.sh"]
+

--- a/src/local.yaml
+++ b/src/local.yaml
@@ -6,7 +6,7 @@ services:
      - "8000:8000"
 
   datomic:
-    image: datomic:0.9.5561
+    image: datomic
     ports:
       - "4334:4334"
     volumes_from:


### PR DESCRIPTION
__WHY__
The file scm-source.json tags the container with SCM identity