### PR TITLE
(#12) : add debug output of latest build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ src/datomic/scm-source.json: force
 run: src/local.yaml
 	docker-compose -f $^ up
 
+debug:
+	@echo ${URL} 
+
 force:
 
 .PHONY: setup upload resources license docker run force


### PR DESCRIPTION
__WHY__
The deployment procedure might require a full identity of the image