### PR TITLE
(#11) : provision cloud watch config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ make run
 ```
 You need to tune `/etc/hosts` of you host environment
 ```
-sudo echo -e "127.0.0.1\tdocker" | tee /etc/hosts
+sudo echo -e "127.0.0.1\tdocker" | tee -a /etc/hosts
 ```
 
 Datomic is available for your peers at  `datomic:ddb-local://127.0.0.1:8000/datomic/yourdb`

--- a/src/aws/resources.yaml
+++ b/src/aws/resources.yaml
@@ -106,10 +106,23 @@ Resources:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
-                Action: kms:Decrypt
+                Action: 
+                  - kms:Decrypt
                 Resource: 
                   - !ImportValue "kms-datomic-license-encryption-key"
 
+        - PolicyName: AllowCloudWatch
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricData
+                  - cloudwatch:PutMetricDataBatch
+                Resource: "*"
+                Condition:
+                  Bool:
+                    aws:SecureTransport: true
 
   PeerRole:
     Type: AWS::IAM::Role

--- a/src/datomic/run.sh
+++ b/src/datomic/run.sh
@@ -36,4 +36,8 @@ fi
 
 ##
 echo "==> spawn transactor"
-/usr/local/datomic/bin/transactor ${CONFIG}
+
+MEM_HOST_KB=$(cat /proc/meminfo | sed -n 's/MemTotal:[ ]*\([0-9]*\).*/\1/p')
+MEM_JAVA_KB=$(($MEM_HOST_KB * 80 / 100))
+
+/usr/local/datomic/bin/transactor -Xmx${MEM_JAVA_KB}k -Xms${MEM_JAVA_KB}k ${CONFIG}


### PR DESCRIPTION
__WHY__
See #11
* enable datomic with cloud watch i/o rights
* tune transactor memory for dynamic discovery